### PR TITLE
Fixed locale support even more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,10 @@ node_js:
 os:
     - linux
     - osx
+env:
+    - LANG=en_US.UTF-8
+    # Number formatting: 1.000.000,01
+    - LANG=de_DE.UTF-8
+    # Number formatting: 10,00,000.01
+    - LANG=hi_IN.UTF-8
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ node_js:
 os:
     - linux
     - osx
-env:
-    - LANG=en_US.UTF-8
-    # Number formatting: 1.000.000,01
-    - LANG=de_DE.UTF-8
-    # Number formatting: 10,00,000.01
-    - LANG=hi_IN.UTF-8
+matrix:
+    include:
+        - node_js: node
+          env: LANG=en_US.UTF-8
+        # Number formatting: 1.000.000,01
+        - node_js: node
+          env: LANG=de_DE.UTF-8
+        # Number formatting: 10,00,000.01
+        - node_js: node
+          env: LANG=hi_IN.UTF-8
 sudo: false

--- a/src/baselib-str.pyj
+++ b/src/baselib-str.pyj
@@ -5,10 +5,12 @@
 # globals: ρσ_kwargs_symbol, ρσ_list_decorate, ρσ_iterator_symbol, HTMLElement
 
 # Locale can’t be changed in-flight, so we just retrieve this once.
-decimal_sep = Intl.NumberFormat() \
-    .formatToParts(1.1) \
-    .find(def(part): return part.type == 'decimal';) \
-    .value
+# Sadly older node version don’t support formatToParts
+# decimal_sep = Intl.NumberFormat() \
+#     .formatToParts(1.1) \
+#     .find(def(part): return part.type == 'decimal';) \
+#     .value
+decimal_sep = (1.1).toLocaleString()[1]
 
 def ρσ_repr_js_builtin(x, as_array):
     ans = v'[]'

--- a/src/baselib-str.pyj
+++ b/src/baselib-str.pyj
@@ -4,6 +4,12 @@
 
 # globals: ρσ_kwargs_symbol, ρσ_list_decorate, ρσ_iterator_symbol, HTMLElement
 
+# Locale can’t be changed in-flight, so we just retrieve this once.
+decimal_sep = Intl.NumberFormat() \
+    .formatToParts(1.1) \
+    .find(def(part): return part.type == 'decimal';) \
+    .value
+
 def ρσ_repr_js_builtin(x, as_array):
     ans = v'[]'
     b = '{}'
@@ -174,7 +180,7 @@ define_str_func('format', def ():
                 (\#)? # integer base specifier
                 (0)? # zero-padding
                 (\d+)? # width
-                ([,_])? # use a comma thousands-seperator
+                ([,_])? # use a grouping (thousands) seperator
                 (?:\.(\d+))? # precision
                 ([bcdeEfFgGnosxX%])? # type
             ///
@@ -253,7 +259,7 @@ define_str_func('format', def ():
                 else:
                     value = value.toExponential(prec - 1)
                 value = value.replace(/0+$/g, '')
-                if value[-1] is '.':
+                if value[-1] == decimal_sep:
                     value = value[:-1]
                 if ftype is 'G':
                     value = value.toUpperCase()

--- a/test/str.pyj
+++ b/test/str.pyj
@@ -59,6 +59,8 @@ test('x', '{}', def (): return 'x';)
 test('11', '{:b}', 3)
 test('0b11', '{:#b}', 3)
 test((30000).toLocaleString(), '{:,d}', 30000)
+# in e.g. the indian number system, this is 3,00,000
+test((300000).toLocaleString(), '{:,d}', 300000)
 test('1.234568e+8', '{:e}', 123456789)
 test('1.23E+8', '{:.2E}', 123456789)
 test('12.35%', '{:.2%}', .123456789)
@@ -69,8 +71,7 @@ test((1234).toLocaleString(undefined, {'minimumFractionDigits': 6}), '{:,f}', 12
 # 1234.0% or 1234,0%
 test((1234).toLocaleString(undefined, {'minimumFractionDigits': 1}) + '%', '{:,.1%}', 12.34)
 test((1234.57).toLocaleString(), '{:,g}', 1234.567)
-# this will get a trailing comma
-test((1234.1).toLocaleString().substr(0, 5), '{:,g}', 1234)
+test((1234).toLocaleString(), '{:,g}', 1234)
 fnum = 1234
 ae(f'{fnum:,}', (1234).toLocaleString())
 test('left aligned                  ', '{:<30}', 'left aligned')


### PR DESCRIPTION
Fixes #138

A proper version to determine the decimal separator using `formatToParts` fails on older node versions. That’s because either node 6&7 on travis are built without full ICU support or because formatToParts didn’t exist in node 6/7 times.

I’m now doing it via `(1.1).toLocaleString()[1]`, but that looks hacky.